### PR TITLE
Pr

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -8,6 +8,7 @@ module.exports = NodeHelper.create({
 
     config: {
         refreshInterval: 0.5 * 60 * 60 * 24, // twice / day
+        showAge: true
     },
 
     start: function() {
@@ -32,6 +33,7 @@ module.exports = NodeHelper.create({
     
     _createIcalEvents: function(birthdays) {
         birthdays.forEach(person => {
+            var thisYear = new Date().getYear()+1900;
             var date = moment({ day: person.birthday.day,
                                 month: person.birthday.month - 1,
                                 year: person.birthday.year,
@@ -39,7 +41,7 @@ module.exports = NodeHelper.create({
             this.ical.createEvent({
                 start: date,
                 repeating: person.birthday.year ? { freq: 'YEARLY' } : undefined, // repeat yearly if a year is set
-                summary: `${person.name}`,
+                summary: `${person.name}` + (this.config.showAge && person.birthday.year ? ` (${thisYear - person.birthday.year})` : ''),
                 allDay: true
             });
         });

--- a/node_helper.js
+++ b/node_helper.js
@@ -6,9 +6,16 @@ const apiHelper = require("./google-api-helper");
 module.exports = NodeHelper.create({
     requiresVersion: '2.6.0', // 2.6.0 got a fix for recurring events before 1970, which is pretty usefull for birthdays :D
 
+    config: {
+        refreshInterval: 0.5 * 60 * 60 * 24, // twice / day
+    },
+
     start: function() {
 
         this._refreshData();
+
+        var self = this;
+        this.refreshInterval = setInterval(()=>{ self._refreshData() }, this.config.refreshInterval);
 
         this.expressApp.use("/" + this.name, (req, res) => {
             this.ical.serve(res)
@@ -17,7 +24,7 @@ module.exports = NodeHelper.create({
         this._log('Server is running')
     },
 
-	stop: function() {
+    stop: function() {
         this._log("Stopping helper");
     },
     


### PR DESCRIPTION
This PR adds two functions:
- refresh the birthdays twice per day
- show the age if birth year is set

Bot of these are configurable. For now the config is hard coded in the source of node_helper.js. In the future it would be nice if these settings would be configurable through the config.js.

You might want to set the `showAge` to `false` by default to be more backwards compatible.