### PR TITLE
Fix fullday event generation

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -25,7 +25,8 @@ module.exports = NodeHelper.create({
     
     _createIcalEvents: function(birthdays) {
         birthdays.forEach(person => {
-            var date = moment([person.birthday.year, person.birthday.month - 1, person.birthday.day]);
+            var year = person.birthday.year || new Date().getFullYear();
+            var date = moment([year, person.birthday.month - 1, person.birthday.day]);
             this.ical.createEvent({
                 start: date,
                 end: date.add(1,'day'),

--- a/node_helper.js
+++ b/node_helper.js
@@ -17,7 +17,7 @@ module.exports = NodeHelper.create({
         this._log('Server is running')
     },
 
-	stop: function() {
+    stop: function() {
         this._log("Stopping helper");
     },
     
@@ -25,12 +25,10 @@ module.exports = NodeHelper.create({
     
     _createIcalEvents: function(birthdays) {
         birthdays.forEach(person => {
-            var date = moment({ day: person.birthday.day,
-                                month: person.birthday.month - 1,
-                                year: person.birthday.year,
-                                hour: 12, minute: 0 , second: 0} );
+            var date = moment([person.birthday.year, person.birthday.month - 1, person.birthday.day]);
             this.ical.createEvent({
                 start: date,
+                end: date.add(1,'day'),
                 repeating: person.birthday.year ? { freq: 'YEARLY' } : undefined, // repeat yearly if a year is set
                 summary: `${person.name}`,
                 allDay: true


### PR DESCRIPTION
The birthdays were not interpreted as full day events in my calendar, which led to dates such as "Tomorrow at 22:00" instead of just "Tomorrow". This might have to do with updates in dependencies of the calendar module and/or my timezone (CEST).

The issue wasn't present when I switched my MagicMirror's timezone to UTC.

This PR fixes the issue at was tested with the latest MagicMirror code for CEST and UTC.